### PR TITLE
[fix/home] 검색 화면 마이너 이슈 수정

### DIFF
--- a/feature/search/src/main/java/com/project/marvelapp/SearchResultViewModel.kt
+++ b/feature/search/src/main/java/com/project/marvelapp/SearchResultViewModel.kt
@@ -56,6 +56,7 @@ class SearchResultViewModel @Inject constructor(
                 if (keyword.length >= 2) {
                     _viewState.update { SearchUiState.Loading }
                     offset = 0
+                    _characterList.update { null }
                     fetchResults(keyword, offset)
                 } else if (keyword.isNotEmpty()) {
                     _viewState.update { SearchUiState.Error("최소 2글자 입력 해야 합니다.") }

--- a/feature/search/src/main/java/com/project/marvelapp/SearchResultViewModel.kt
+++ b/feature/search/src/main/java/com/project/marvelapp/SearchResultViewModel.kt
@@ -94,7 +94,9 @@ class SearchResultViewModel @Inject constructor(
     private fun fetchResults(keyword: String, offset: Int) = viewModelScope.launch {
         getCharactersUseCase(keyword, offset)
             .onEach { result ->
-                if (result.size == _characterList.value?.size) {
+                if (result.isEmpty()) {
+                    _viewState.update { SearchUiState.Error("검색 결과가 없습니다.") }
+                } else if (offset > 0 && result.size == _characterList.value?.size) {
                     _viewState.update {
                         SearchUiState.Success(
                             characters = (it as SearchUiState.Success).characters,

--- a/feature/search/src/main/java/com/project/marvelapp/SearchScreen.kt
+++ b/feature/search/src/main/java/com/project/marvelapp/SearchScreen.kt
@@ -109,9 +109,7 @@ fun CharacterScreen(
                             buffer = 0,
                         )
                     }
-                    if (viewState.characters.isEmpty()) {
-                        MessageBoxLayout(message = "검색 결과가 없습니다.")
-                    } else {
+                    if (viewState.characters.isNotEmpty()) {
                         Box(
                             modifier = Modifier.fillMaxHeight()
                         ) {

--- a/feature/search/src/main/java/com/project/marvelapp/SearchScreen.kt
+++ b/feature/search/src/main/java/com/project/marvelapp/SearchScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -111,7 +112,9 @@ fun CharacterScreen(
                     if (viewState.characters.isEmpty()) {
                         MessageBoxLayout(message = "검색 결과가 없습니다.")
                     } else {
-                        Box {
+                        Box(
+                            modifier = Modifier.fillMaxHeight()
+                        ) {
                             LazyVerticalGrid(
                                 state = lazyListState,
                                 columns = GridCells.Fixed(2)


### PR DESCRIPTION
### 작업 내용
- 검색어를 천천히 입력하는 경우, 결과 값에 따른 대응 처리 추가
- 검색어에 따른 결과가 비어있는 경우, 성공이 아닌 에러로 처리하여 문구 노출
- 검색어(bat) 입력 후, 3개의 응답 저장 후, 검색어(batm) 입력 후, 응답 결과가 없어서 에러 처리. 그리고 다시 m을 지우고 검색어(bat)로 재검색 시, 캐시된 리스트와 동일한 값이라서 stateflow가 동작하지 않음. 그래서 검색어가 변경될 때 마다 null 처리 추가
