### PR TITLE
[fix/search_keyword_state] 탭 전환 시, 새로 로드되는 이슈 수정

### DIFF
--- a/feature/search/src/main/java/com/project/marvelapp/SearchResultViewModel.kt
+++ b/feature/search/src/main/java/com/project/marvelapp/SearchResultViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -88,7 +87,11 @@ class SearchResultViewModel @Inject constructor(
     }
 
     fun updateKeyword(keyword: String) = _searchParamState.update {
-        it.copy(searchQuery = keyword, offset = 0)
+        if (keyword != it.searchQuery) {
+            it.copy(searchQuery = keyword, offset = 0)
+        } else {
+            it
+        }
     }
 
     fun addFavorite(model: CharacterUiModel) = addFavoriteCharacterUseCase(model.toEntity())


### PR DESCRIPTION
### 작업 내용
- 검색 탭 시마다 keyword Stateflow에 키워드가 새로 설정되어 초기 로드가 진행되는 현상 수정
- 키워드가 이전 키워드와 같다면 copy하지 않는 방식으로 수정