### PR TITLE
[feat/character-repository-unittest] CharacterRepository 유닛 테스트 추가 

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 
 dependencies {
     implementation(project(":core:domain"))
+    testImplementation(project(":core:testing"))
 
     implementation(AndroidX.CORE_KTX)
 

--- a/core/data/src/test/java/com/project/marvelapp/repository/CharacterRepositoryTest.kt
+++ b/core/data/src/test/java/com/project/marvelapp/repository/CharacterRepositoryTest.kt
@@ -1,0 +1,105 @@
+package com.project.marvelapp.repository
+
+import com.project.marvelapp.datasource.TestCharacterDataSource
+import com.project.marvelapp.dispatcher.TestCoroutinesRule
+import com.project.marvelapp.fakeSuccessCharacterResponse
+import kotlinx.coroutines.flow.first
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.junit.MockitoJUnitRunner
+import kotlin.test.assertEquals
+
+@RunWith(MockitoJUnitRunner::class)
+class CharacterRepositoryTest {
+
+    @get:Rule
+    val coroutineRule = TestCoroutinesRule()
+
+    private val characterDataSource = TestCharacterDataSource()
+
+    lateinit var characterRepository: CharacterRepository
+
+    @Before
+    fun setUp() {
+        characterRepository = CharacterRepositoryImpl(
+            characterDataSource = characterDataSource
+        )
+    }
+
+    @Test
+    fun sameResultSize_withSuccessRequest() = coroutineRule.runTest {
+        characterDataSource.setSuccessFlag(true)
+        characterDataSource.addResponseList(fakeSuccessCharacterResponse)
+
+        val result = characterRepository.getCharacters(keyword = "data", offset = 0).first()
+        val expect = 10
+
+        assertEquals(
+            expect,
+            result.size
+        )
+    }
+
+    @Test
+    fun successButEmptySize_withNoRespondingRequest() = coroutineRule.runTest {
+        characterDataSource.setSuccessFlag(true)
+        characterDataSource.addResponseList(emptyList())
+
+        val result = characterRepository.getCharacters(keyword = "data", offset = 0).first()
+        val expect = 0
+
+        assertEquals(
+            expect,
+            result.size
+        )
+    }
+
+    @Test
+    fun original10Data_pagination10Data() = coroutineRule.runTest {
+        characterDataSource.setSuccessFlag(true)
+        characterDataSource.addResponseList(fakeSuccessCharacterResponse)
+
+        val result = characterRepository.getCharacters(keyword = "data", offset = 0).first()
+        val expect = 10
+
+        assertEquals(
+            expect,
+            result.size
+        )
+
+        val pagingResult = characterRepository.getCharacters(keyword = "data", offset = 10).first()
+        val pagingExpect = 20
+
+        assertEquals(
+            pagingExpect,
+            pagingResult.size
+        )
+    }
+
+    @Test
+    fun original10Data_pagination2Data() = coroutineRule.runTest {
+        characterDataSource.setSuccessFlag(true)
+        characterDataSource.addResponseList(fakeSuccessCharacterResponse)
+
+        val result = characterRepository.getCharacters(keyword = "data", offset = 0).first()
+        val expect = 10
+
+        assertEquals(
+            expect,
+            result.size
+        )
+
+        characterDataSource.clearResponseList()
+        characterDataSource.addResponseList(fakeSuccessCharacterResponse.take(2))
+
+        val pagingResult = characterRepository.getCharacters(keyword = "data", offset = 10).first()
+        val pagingExpect = 12
+
+        assertEquals(
+            pagingExpect,
+            pagingResult.size
+        )
+    }
+}

--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 dependencies {
     implementation(Kotlin.COROUTINES_CORE)
     implementation(Kotlin.KOTLIN_STDLIB)
+    implementation(Libraries.RETROFIT_CONVERTER_GSON)
     implementation("androidx.annotation:annotation-jvm:+")
 
     testImplementation(UnitTest.JUNIT)
@@ -46,8 +47,8 @@ dependencies {
     testImplementation(UnitTest.CORE_TESTING)
     testImplementation(UnitTest.COROUTINE_TEST)
     androidTestImplementation(UnitTest.ANDROID_JUNIT_EXT)
-    implementation(project(":core:model"))
 
+    implementation(project(":core:model"))
     implementation(project(":core:data"))
     implementation(project(":core:domain"))
 }

--- a/core/testing/src/main/java/com/project/marvelapp/CharactersTestData.kt
+++ b/core/testing/src/main/java/com/project/marvelapp/CharactersTestData.kt
@@ -2,6 +2,11 @@ package com.project.marvelapp
 
 import com.project.marvelapp.common.CharacterUiModel
 import com.project.marvelapp.entity.CharacterEntity
+import com.project.marvelapp.model.response.CharacterDataContainerResponse
+import com.project.marvelapp.model.response.CharacterDataWrapperResponse
+import com.project.marvelapp.model.response.CharacterResponse
+import com.project.marvelapp.model.response.ThumbnailResponse
+import com.project.marvelapp.model.vo.CharacterVO
 
 val testCharactersData = listOf<CharacterEntity>(
     CharacterEntity(id = 1, name = "xxx1"),
@@ -24,3 +29,133 @@ val testFavoriteCharacterUiModelList = listOf<CharacterUiModel>(
 )
 
 val testFavoriteCharacterUiModel = CharacterUiModel(id = 7, name = "batman", isFavorite = true)
+
+val fakeSuccessCharacterResponse = listOf(
+    CharacterResponse(
+        id = 1,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "batman"
+    ),
+    CharacterResponse(
+        id = 2,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "ironMan"
+    ),
+    CharacterResponse(
+        id = 3,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 4,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 5,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 6,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 7,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 8,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 9,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+    CharacterResponse(
+        id = 10,
+        thumbnail = ThumbnailResponse(
+            path = "",
+            extension = ""
+        ),
+        description = "",
+        modified = "",
+        name = "spiderMan"
+    ),
+)
+
+val testFavoriteCharacterVoSet = hashSetOf<CharacterVO>(
+    CharacterVO(
+        id = 1,
+        name = "batman",
+        description = "mask on",
+        modified = "",
+        thumbnail = "http://i.annihil.us/u/prod/marvel/i/mg/b/40/image_not_available.jpg",
+        savedTime = 5L
+    ),
+    CharacterVO(
+        id = 2,
+        name = "spider",
+        description = "whip",
+        modified = "",
+        thumbnail = "http://i.annihil.us/u/prod/marvel/i/mg/b/40/image_not_available.jpg",
+        savedTime = 3L
+    ),
+    CharacterVO(
+        id = 3,
+        name = "ironman",
+        description = "steel",
+        modified = "",
+        thumbnail = "http://i.annihil.us/u/prod/marvel/i/mg/b/40/image_not_available.jpg",
+        savedTime = 4L
+    )
+)

--- a/core/testing/src/main/java/com/project/marvelapp/datasource/TestCharacterDataSource.kt
+++ b/core/testing/src/main/java/com/project/marvelapp/datasource/TestCharacterDataSource.kt
@@ -1,0 +1,64 @@
+package com.project.marvelapp.datasource
+
+import com.project.marvelapp.datasource.remote.CharacterDataSource
+import com.project.marvelapp.model.response.CharacterDataContainerResponse
+import com.project.marvelapp.model.response.CharacterDataWrapperResponse
+import com.project.marvelapp.model.response.CharacterResponse
+
+class TestCharacterDataSource : CharacterDataSource {
+
+    private val characterList = mutableListOf<CharacterResponse>()
+
+    private var isSuccess = true
+
+    private fun getSuccessCharacterDataWrapperResponse(characterList: List<CharacterResponse>) =
+        CharacterDataWrapperResponse(
+            code = 200,
+            status = "Ok",
+            characterDataContainerResponse = CharacterDataContainerResponse(
+                count = 10,
+                limit = 10,
+                total = 20,
+                offset = 10,
+                results = characterList
+            )
+        )
+
+    private fun getErrorCharacterDataWrapperResponse(characterList: List<CharacterResponse>) =
+        CharacterDataWrapperResponse(
+            code = 200,
+            status = "",
+            characterDataContainerResponse = CharacterDataContainerResponse(
+                count = 10,
+                limit = 10,
+                total = 20,
+                offset = 10,
+                results = characterList
+            )
+        )
+
+
+    override suspend fun getCharacters(
+        keyword: String,
+        limit: Int,
+        offset: Int
+    ): CharacterDataWrapperResponse {
+        return if (isSuccess) {
+            getSuccessCharacterDataWrapperResponse(characterList)
+        } else {
+            getErrorCharacterDataWrapperResponse(characterList)
+        }
+    }
+
+    fun setSuccessFlag(flag: Boolean) {
+        isSuccess = flag
+    }
+
+    fun addResponseList(list: List<CharacterResponse>) {
+        characterList.addAll(list)
+    }
+
+    fun clearResponseList() {
+        characterList.clear()
+    }
+}

--- a/core/testing/src/main/java/com/project/marvelapp/repository/TestCharacterRepository.kt
+++ b/core/testing/src/main/java/com/project/marvelapp/repository/TestCharacterRepository.kt
@@ -1,4 +1,4 @@
-package com.project.marvelapp
+package com.project.marvelapp.repository
 
 import com.project.marvelapp.entity.CharacterEntity
 import com.project.marvelapp.repository.CharacterRepository

--- a/core/testing/src/main/java/com/project/marvelapp/repository/TestUserRepository.kt
+++ b/core/testing/src/main/java/com/project/marvelapp/repository/TestUserRepository.kt
@@ -1,9 +1,8 @@
-package com.project.marvelapp
+package com.project.marvelapp.repository
 
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.project.marvelapp.entity.CharacterEntity
-import com.project.marvelapp.repository.UserPrefRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 

--- a/feature/favorite/src/test/java/com/project/marvelapp/FavoriteViewModelTest.kt
+++ b/feature/favorite/src/test/java/com/project/marvelapp/FavoriteViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.project.marvelapp
 
+import com.project.marvelapp.repository.TestUserRepository
 import com.project.marvelapp.rule.TestCoroutinesRule
 import com.project.marvelapp.usecase.AddFavoriteCharacterUseCase
 import com.project.marvelapp.usecase.DeleteFavoriteCharacterUseCase

--- a/feature/search/src/test/java/com/project/marvelapp/viewmodel/SearchResultViewModelTest.kt
+++ b/feature/search/src/test/java/com/project/marvelapp/viewmodel/SearchResultViewModelTest.kt
@@ -1,9 +1,9 @@
 package com.project.marvelapp.viewmodel
 
 import com.project.marvelapp.SearchResultViewModel
-import com.project.marvelapp.TestCharacterRepository
+import com.project.marvelapp.repository.TestCharacterRepository
 import com.project.marvelapp.TestCoroutinesRule
-import com.project.marvelapp.TestUserRepository
+import com.project.marvelapp.repository.TestUserRepository
 import com.project.marvelapp.state.SearchResultUiState
 import com.project.marvelapp.testCharactersData
 import com.project.marvelapp.testPagingCharactersData


### PR DESCRIPTION
### 작업 내용
- 데이터 레이어의 Repository 유닛 테스트 코드 추가
- Repository 유닛테스트를 위한 Fake Datasource 생성